### PR TITLE
fix(airports-csv-to-json.go): changed json.Marshal to use the airport…

### DIFF
--- a/bin/airports-csv-to-json.go
+++ b/bin/airports-csv-to-json.go
@@ -133,7 +133,7 @@ func main() {
 
 		utcOffset := 0
 		{
-			utcOffsetStr := record[8]
+			utcOffsetStr := record[9]
 			utcOffset, err = strconv.Atoi(utcOffsetStr)
 			if err != nil {
 				fmt.Printf("parse error on line %d (%s): utc_offset: %s\n", i, icao, utcOffsetStr)

--- a/bin/airports-csv-to-json.go
+++ b/bin/airports-csv-to-json.go
@@ -161,7 +161,7 @@ func main() {
 			continue
 		}
 
-		jsonData, err := json.MarshalIndent(airports, "", "    ")
+		jsonData, err := json.MarshalIndent(airport, "", "    ")
 		if err != nil {
 			fmt.Println("Error:", err)
 			return

--- a/bin/airports-csv-to-json.go
+++ b/bin/airports-csv-to-json.go
@@ -20,7 +20,7 @@ type Airport struct {
 	Latitude    float64 `json:"latitude"`
 	Longitude   float64 `json:"longitude"`
 	Elevation   int     `json:"elevation"`
-	UTCOffset   int     `json:"utc_offset"`
+	UTCOffset   float64 `json:"utc_offset"`
 	Class       string  `json:"_class"`
 	Timezone    string  `json:"timezone"`
 }
@@ -131,10 +131,10 @@ func main() {
 			}
 		}
 
-		utcOffset := 0
+		utcOffset := 0.0
 		{
 			utcOffsetStr := record[9]
-			utcOffset, err = strconv.Atoi(utcOffsetStr)
+			utcOffset, err = strconv.ParseFloat(utcOffsetStr, 64)
 			if err != nil {
 				fmt.Printf("parse error on line %d (%s): utc_offset: %s\n", i, icao, utcOffsetStr)
 			}


### PR DESCRIPTION
… instead of the array of airports

I believe this was the intention from what I gleamed on stream, if not, obviously disregard. As of right now, though, the output files contain more than one airport, which breaks continuity with my understanding of the _old_ API.

BREAKING CHANGE: This will completely change all generated files, which are not included in this commit.

This fixes the tool for the generated files, but does not fully resolve #18. Also resolves #20. Seemed strange to create two PR's for minor changes.